### PR TITLE
Add alignment option to messages

### DIFF
--- a/examples/gui.ts
+++ b/examples/gui.ts
@@ -1,4 +1,4 @@
-import { Colors, fromRgb, GUI, Key, Message, MessageDialog, Rect, SelectDialog, Terminal } from '../src/';
+import { Colors, fromRgb, GUI, Key, Message, MessageAlign, MessageDialog, Rect, SelectDialog, Terminal } from '../src/';
 import { ScrollableMessageDialog } from '../src/gui/scrollablemessagedialog';
 
 const term = new Terminal(document.querySelector('canvas') as HTMLCanvasElement, 80, 45);
@@ -36,10 +36,12 @@ term.update = function () {
             new Message('Binds when picked up', Colors.WHITE),
             new Message('Unique-Equipped', Colors.WHITE),
             new Message(' '),
+            new Message('Weapon', Colors.LIGHT_RED, undefined, undefined, MessageAlign.CENTER),
             new Message('One-Hand                              Dagger', Colors.WHITE),
             new Message('195-293 Damage                    Speed 1.70', Colors.WHITE),
             new Message('143.53 damage per second', Colors.WHITE),
             new Message('+43 Stamina', Colors.WHITE),
+            new Message('Total: 1.70', Colors.LIGHT_GRAY, undefined, undefined, MessageAlign.RIGHT),
             new Message(' '),
             new Message('Durability 75 / 75', Colors.WHITE),
             new Message('Requires Level 80', Colors.WHITE),

--- a/src/console.ts
+++ b/src/console.ts
@@ -2,7 +2,7 @@ import { BlendMode } from './blendmode';
 import { Cell } from './cell';
 import { Chars } from './chars';
 import { Color } from './color';
-import { Message } from './gui/message';
+import { Message, MessageAlign } from './gui/message';
 import { Rect } from './rect';
 import { serializable } from './serialize';
 import { wordWrap } from './utils';
@@ -100,8 +100,14 @@ export class Console {
     this.drawString(x - Math.floor(str.length / 2), y, str, fg, bg);
   }
 
-  drawMessage(x: number, y: number, message: Message, maxWidth?: number): number {
+  drawMessage(x: number, y: number, message: Message, maxWidth: number): number {
     if (message.text) {
+      if (message.align === MessageAlign.RIGHT) {
+        x += maxWidth - message.text.length;
+      } else if (message.align === MessageAlign.CENTER) {
+        x += maxWidth / 2 - message.text.length / 2;
+      }
+
       const lines = wordWrap(message.text, maxWidth || this.width - x);
       for (const line of lines) {
         this.drawStringLine(x, y, line, message.fg, message.bg);

--- a/src/gui/message.ts
+++ b/src/gui/message.ts
@@ -1,14 +1,21 @@
 import { Color } from '../color';
 import { serializable } from '../serialize';
 
+export enum MessageAlign {
+  LEFT,
+  CENTER,
+  RIGHT
+}
+
 @serializable
 export class Message {
   constructor(
     readonly text: string | undefined,
     readonly fg?: Color | undefined,
     readonly bg?: Color | undefined,
-    readonly children?: Message[]
-  ) {}
+    readonly children?: Message[],
+    readonly align?: MessageAlign
+  ) { }
 
   getWidth(): number {
     let width = 0;

--- a/src/gui/messagedialog.ts
+++ b/src/gui/messagedialog.ts
@@ -19,7 +19,7 @@ export class MessageDialog extends Dialog {
 
   drawContents(console: Console, offset: Point): void {
     if (this.message instanceof Message) {
-      console.drawMessage(offset.x, offset.y, this.message);
+      console.drawMessage(offset.x, offset.y, this.message, this.message.getWidth());
     } else {
       console.drawString(offset.x, offset.y, this.message);
     }

--- a/src/gui/scrollablemessagedialog.ts
+++ b/src/gui/scrollablemessagedialog.ts
@@ -22,7 +22,7 @@ export class ScrollableMessageDialog extends Dialog {
 
   drawContents(console: Console, offset: Point): void {
     console.clip = this.contentsRect;
-    console.drawMessage(offset.x, offset.y - this.scrollY, this.message);
+    console.drawMessage(offset.x, offset.y - this.scrollY, this.message, this.message.getWidth());
     console.clip = undefined;
 
     // Draw scrollbar

--- a/src/input.ts
+++ b/src/input.ts
@@ -11,7 +11,7 @@ const INPUT_REPEAT_DELAY = 200.0;
 const INPUT_REPEAT_RATE = 1000.0 / 15.0;
 
 /**
- * The Input class represents a pysical input.
+ * The Input class represents a physical input.
  * Example: keyboard key or mouse button.
  */
 export class Input {


### PR DESCRIPTION
Add alignment option for messages (Center and right, left remain as the default):

![image](https://user-images.githubusercontent.com/8084300/204069780-e4a6e598-ad05-4739-bdfb-4e29ffb02c75.png)

Hi @codyebberson, please feel free to suggest/modify things, I am not much happy with the two `undefined` being passed just to reach the new `align` parameter position, so if you agree we could turn the `Message` constructor  into a JSON config object so that instead of this:
```javascript
new Message('Weapon', Colors.LIGHT_RED, undefined, undefined, MessageAlign.CENTER)
```
We would be able to do this:
```javascript
new Message({ text: 'Weapon', fg: Colors.LIGHT_RED, align: MessageAlign.CENTER })
```
